### PR TITLE
replace /dev/shm/$uuid by actual random tmpfile

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -55,12 +53,7 @@ func (e Editor) Launch(path string) error {
 }
 
 func (e Editor) LaunchTemp(r io.Reader) ([]byte, string, error) {
-	uuid, err := uuid.NewRandom()
-	if err != nil {
-		return []byte{}, "", err
-	}
-	tmpf := fmt.Sprintf("/dev/shm/%v", uuid)
-	f, err := os.OpenFile(tmpf, os.O_RDWR|os.O_CREATE, 0600)
+	f, err := ioutil.TempFile("", "*.helm")
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
`/dev/shm` is linux only and shouldn't be used even there. Modern
systems do have a `tmpfs` at `/tmp`, where it belongs.
`ioutil.TempFile` creates a temp file based upon `os.TempDir`, so it
works independent of the actual OS.